### PR TITLE
Add component for exam links

### DIFF
--- a/components/ExamLink.tsx
+++ b/components/ExamLink.tsx
@@ -1,0 +1,44 @@
+import Link, { LinkProps } from "next/link";
+import clsx from "clsx";
+import { AnchorHTMLAttributes } from "react";
+
+interface ExamLinkProps
+  extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href">,
+    LinkProps {
+  heading: string;
+  paragraph: string;
+  wrapperClassNames?: string;
+  headingClassNames?: string;
+}
+
+const ExamLink = ({
+  heading,
+  paragraph,
+  wrapperClassNames,
+  headingClassNames,
+  ...linkProps
+}: ExamLinkProps) => {
+  return (
+    <Link
+      {...linkProps}
+      className={clsx(
+        wrapperClassNames,
+        "group bg-slate-700 hover:bg-gradient-to-r rounded-xl p-[2px] w-full h-[350px] cursor-pointer"
+      )}
+    >
+      <div
+        className={clsx(
+          headingClassNames,
+          "flex flex-col h-full bg-slate-800 rounded-xl pt-[40%] px-7"
+        )}
+      >
+        <h2 className="text-white group-hover:bg-gradient-to-r group-hover:text-transparent bg-clip-text uppercase text-3xl font-bold">
+          {heading}
+        </h2>
+        <p className="text-sm text-slate-400 mt-7">{paragraph}</p>
+      </div>
+    </Link>
+  );
+};
+
+export default ExamLink;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import type { NextPage } from "next";
+import ExamLink from "@azure-fundamentals/components/ExamLink";
 
 const Home: NextPage = () => {
   return (
@@ -10,33 +10,21 @@ const Home: NextPage = () => {
         own pace with our practice mode.
       </p>
       <div className="flex max-sm:flex-col max-sm:align-center justify-center gap-4">
-        <Link
+        <ExamLink
           href="/practice"
-          className="group bg-slate-700 hover:bg-gradient-to-r from-[#0284C7] to-[#2DD48F] rounded-xl p-[2px] w-full h-[350px] cursor-pointer"
-        >
-          <div className="flex flex-col h-full bg-slate-800 rounded-xl pt-[40%] px-7">
-            <h2 className="text-white group-hover:bg-gradient-to-r group-hover:from-[#0284C7] group-hover:to-[#2DD48F] group-hover:text-transparent bg-clip-text uppercase text-3xl font-bold">
-              Practice mode
-            </h2>
-            <p className="text-sm text-slate-400 mt-7">
-              Learn and familiarize yourself with the questions and answers without any time constraint.
-            </p>
-          </div>
-        </Link>
-        <Link
+          heading="Practice mode"
+          paragraph="Learn and familiarize yourself with the questions and answers without any time constraint."
+          wrapperClassNames="from-[#0284C7] to-[#2DD48F]"
+          headingClassNames="group-hover:from-[#0284C7] group-hover:to-[#2DD48F]"
+        />
+        <ExamLink
           href="/exam"
-          className="group bg-slate-700 hover:bg-gradient-to-r from-[#F97316] to-[#FACC15] rounded-xl p-[2px] w-full h-[350px] cursor-pointer"
-        >
-          <div className="flex flex-col h-full bg-slate-800 rounded-xl pt-[40%] px-7">
-            <h2 className="text-white group-hover:bg-gradient-to-r group-hover:from-[#F97316] group-hover:to-[#FACC15] group-hover:text-transparent bg-clip-text uppercase text-3xl font-bold">
-              Exam mode
-            </h2>
-            <p className="text-sm text-slate-400 mt-7">
-              Put your knowledge to the test by answering a fixed number of randomly selected questions under a time
-              limit.
-            </p>
-          </div>
-        </Link>
+          heading="Exam mode"
+          paragraph="Put your knowledge to the test by answering a fixed number of randomly selected questions under a time
+            limit."
+          wrapperClassNames="from-[#F97316] to-[#FACC15]"
+          headingClassNames="group-hover:from-[#F97316] group-hover:to-[#FACC15]"
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
<!--
Thank you for opening this pull request! Your help is much appreciated.
Please choose the PR Type and give as many details as possible about your PR.
-->

Fixes #31 <!-- link to issue if one exists -->

- [x] I have read and agree to the [Code of Conduct](https://github.com/eduardconstantin/azure-fundamentals/blob/main/CODE_OF_CONDUCT.md), and have followed the [Contributing guidelines](https://github.com/eduardconstantin/azure-fundamentals/blob/main/CONTRIBUTING.md).

## Pull Request Type

<!-- Please delete options that are not relevant -->

- [x] New feature

## Summary

<!--
 Detailed explanation for the changes of your pull request
-->

I have implemented a generic component for home page links. I wasn't sure if we wanted just two variants (differences in gradients) or fully customizable classes like now.